### PR TITLE
Upgrade al2 instances to al2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The fleet of instances deployed is as follows.
 
 | Operating System        | Architecture    | Type      |
 | ----------------------- | --------------- | --------- |
-| Amazon Linux 2          | x86_64  (amd64) | t3.small  |
-| Amazon Linux 2          | aarch64 (arm64) | t4g.small |
+| Amazon Linux 2023       | x86_64  (amd64) | t3.small  |
+| Amazon Linux 2023       | aarch64 (arm64) | t4g.small |
 | Ubuntu Server 22.04 LTS | x86_64  (amd64) | t3.small  |
 | Ubuntu Server 22.04 LTS | aarch64 (arm64) | t4g.small |
 | Ubuntu Server 20.04 LTS | x86_64  (amd64) | t3.small  |


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

Upgrade Amazon Linux 2 instances to Amazon Linux 2023.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
